### PR TITLE
Update CONFIG_PATH and custom port in docker-compose.yml

### DIFF
--- a/docs/Installation/installation-docker.md
+++ b/docs/Installation/installation-docker.md
@@ -35,7 +35,8 @@ services:
     ports:
       - 8080:3006
     environment:
-      - PORT:3006
+      - PORT=3006
+      - CONFIG_PATH=/app/config/
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /local/path/config/dir:/app/config


### PR DESCRIPTION
Added the environmental variable `CONFIG_PATH` and changed syntax for `PORT=3006` (replaced ':' with '=', as the former didn't work) in example docker-compose.yml file.